### PR TITLE
Removes padding usage on Vec3 and Mat3 types

### DIFF
--- a/include/math/mat3_t.hpp
+++ b/include/math/mat3_t.hpp
@@ -161,13 +161,7 @@ template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
 LM_INLINE auto operator+(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     -> Matrix3<T> {
     Matrix3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_add_mat3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_add_mat3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#else
     scalar::kernel_add_mat3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#endif
     return dst;
 }
 
@@ -175,45 +169,23 @@ template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
 LM_INLINE auto operator-(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     -> Matrix3<T> {
     Matrix3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_sub_mat3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_sub_mat3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#else
     scalar::kernel_sub_mat3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#endif
     return dst;
 }
 
 template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
 LM_INLINE auto operator*(double scale, const Matrix3<T>& mat) -> Matrix3<T> {
     Matrix3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_scale_mat3(dst.elements(), static_cast<T>(scale),
-                           mat.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_scale_mat3<T>(dst.elements(), static_cast<T>(scale),
-                              mat.elements());
-#else
     scalar::kernel_scale_mat3<T>(dst.elements(), static_cast<T>(scale),
                                  mat.elements());
-#endif
     return dst;
 }
 
 template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
 LM_INLINE auto operator*(const Matrix3<T>& mat, double scale) -> Matrix3<T> {
     Matrix3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_scale_mat3(dst.elements(), static_cast<T>(scale),
-                           mat.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_scale_mat3<T>(dst.elements(), static_cast<T>(scale),
-                              mat.elements());
-#else
     scalar::kernel_scale_mat3<T>(dst.elements(), static_cast<T>(scale),
                                  mat.elements());
-#endif
     return dst;
 }
 
@@ -221,14 +193,8 @@ template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
 LM_INLINE auto operator*(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     -> Matrix3<T> {
     Matrix3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_matmul_mat3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_matmul_mat3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#else
     scalar::kernel_matmul_mat3<T>(dst.elements(), lhs.elements(),
                                   rhs.elements());
-#endif
     return dst;
 }
 
@@ -236,16 +202,8 @@ template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
 LM_INLINE auto operator*(const Matrix3<T>& lhs_mat, const Vector3<T>& rhs_vec)
     -> Vector3<T> {
     Vector3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_matmul_vec_mat3<T>(dst.elements(), lhs_mat.elements(),
-                                   rhs_vec.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_matmul_vec_mat3<T>(dst.elements(), lhs_mat.elements(),
-                                   rhs_vec.elements());
-#else
     scalar::kernel_matmul_vec_mat3<T>(dst.elements(), lhs_mat.elements(),
                                       rhs_vec.elements());
-#endif
     return dst;
 }
 
@@ -253,16 +211,8 @@ template <typename T, SFINAE_MAT3_GUARD<T> = nullptr>
 LM_INLINE auto hadamard(const Matrix3<T>& lhs, const Matrix3<T>& rhs)
     -> Matrix3<T> {
     Matrix3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_hadamard_mat3<T>(dst.elements(), lhs.elements(),
-                                 rhs.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_hadamard_mat3<T>(dst.elements(), lhs.elements(),
-                                 rhs.elements());
-#else
     scalar::kernel_hadamard_mat3<T>(dst.elements(), lhs.elements(),
                                     rhs.elements());
-#endif
     return dst;
 }
 

--- a/include/math/mat3_t_decl.hpp
+++ b/include/math/mat3_t_decl.hpp
@@ -32,18 +32,12 @@ namespace math {
 ///
 /// This is a class that represents 3x3 matrices with real-valued entries. The
 /// internal data is stored as the columns of the matrix using 3d vectors of the
-/// same scalar type. The resulting storage is column major and aligned in a way
-/// that allows the use of aligned versions of some SIMD instructions (when
-/// using either SSE or AVX instrinsics).
+/// same scalar type, thus using a column major order.
 template <typename Scalar_T>
 class Matrix3 {
  public:
-    /// Number of scalars used for the storage of this matrix. Notice that as
-    /// we're using vec3 as the columns of the matrix, and these are padded by
-    /// one float (4 floats per vec3), so we're actually using 12 f32 elements
-    static constexpr uint32_t BUFFER_SIZE = 12;
-    /// Alignment factor for the internal buffer (see m_Elements)
-    static constexpr uint32_t ALIGN_SIZE = 16;
+    /// Number of scalars used for the storage of this matrix
+    static constexpr uint32_t BUFFER_SIZE = 9;
     /// Number of dimensions of the matrix (square 3x3 matrix)
     static constexpr uint32_t MATRIX_SIZE = 3;
     /// Number of dimensions of this matrix (as in numpy.ndarray.ndim)
@@ -197,8 +191,7 @@ class Matrix3 {
     }
 
  private:
-    /// The buffer where all data is stored (as an array of 3 column
-    /// vectors)
+    /// The buffer where all data is stored
     BufferType m_Elements;
 };
 

--- a/include/math/vec3_t.hpp
+++ b/include/math/vec3_t.hpp
@@ -14,63 +14,33 @@ using SFINAE_VEC3_GUARD = typename std::enable_if<IsScalar<T>::value>::type*;
 /// \brief Returns the square of the norm-2 of the vector
 template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto squareNorm(const Vector3<T>& vec) -> T {
-#if defined(MATH_AVX_ENABLED)
-    return avx::kernel_length_square_vec3<T>(vec.elements());
-#elif defined(MATH_SSE_ENABLED)
-    return sse::kernel_length_square_vec3<T>(vec.elements());
-#else
     return scalar::kernel_length_square_vec3<T>(vec.elements());
-#endif
 }
 
 /// \brief Returns the norm-2 of the vector
 template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto norm(const Vector3<T>& vec) -> T {
-#if defined(MATH_AVX_ENABLED)
-    return avx::kernel_length_vec3<T>(vec.elements());
-#elif defined(MATH_SSE_ENABLED)
-    return sse::kernel_length_vec3<T>(vec.elements());
-#else
     return std::sqrt(scalar::kernel_length_square_vec3<T>(vec.elements()));
-#endif
 }
 
 /// \brief Returns a normalized version of this vector
 template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto normalize(const Vector3<T>& vec) -> Vector3<T> {
     Vector3<T> vec_normalized = vec;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_normalize_in_place_vec3<T>(vec_normalized.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_normalize_in_place_vec3<T>(vec_normalized.elements());
-#else
     scalar::kernel_normalize_in_place_vec3<T>(vec_normalized.elements());
-#endif
     return vec_normalized;
 }
 
 /// \brief Normalizes in-place the given vector
 template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto normalize_in_place(Vector3<T>& vec) -> void {  // NOLINT
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_normalize_in_place_vec3<T>(vec.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_normalize_in_place_vec3<T>(vec.elements());
-#else
     scalar::kernel_normalize_in_place_vec3<T>(vec.elements());
-#endif
 }
 
 /// \brief Returns the dot-product of the given two vectors
 template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto dot(const Vector3<T>& lhs, const Vector3<T>& rhs) -> T {
-#if defined(MATH_AVX_ENABLED)
-    return avx::kernel_dot_vec3<T>(lhs.elements(), rhs.elements());
-#elif defined(MATH_SSE_ENABLED)
-    return sse::kernel_dot_vec3<T>(lhs.elements(), rhs.elements());
-#else
     return scalar::kernel_dot_vec3<T>(lhs.elements(), rhs.elements());
-#endif
 }
 
 /// \brief Returns the cross-product of the given two vectors
@@ -78,28 +48,14 @@ template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto cross(const Vector3<T>& lhs, const Vector3<T>& rhs)
     -> Vector3<T> {
     Vector3<T> vec_cross;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_cross_vec3<T>(vec_cross.elements(), lhs.elements(),
-                              rhs.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_cross_vec3<T>(vec_cross.elements(), lhs.elements(),
-                              rhs.elements());
-#else
     scalar::kernel_cross_vec3<T>(vec_cross.elements(), lhs.elements(),
                                  rhs.elements());
-#endif
     return vec_cross;
 }
 
 /// \brief Returns the vector-sum of two 3d vector operands
 ///
-/// \tparam T Type of scalar value used for the 3d-vector operands
-///
-/// This operator implements an element-wise sum of two Vector3 operands given
-/// as input arguments. The internal operator selects the appropriate "kernel"
-/// (just a function) to which to call, depending on whether or not the library
-/// was compiled using SIMD support (i.e. SSE and AVX function intrinsics will
-/// be used to handle the operation).
+/// \tparam T Type of scalar used by both scalar and vector operands
 ///
 /// \param[in] lhs Left-hand-side operand of the vector-sum
 /// \param[in] rhs Right-hand-side operand of the vector-sum
@@ -107,25 +63,13 @@ template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto operator+(const Vector3<T>& lhs, const Vector3<T>& rhs)
     -> Vector3<T> {
     Vector3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_add_vec3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_add_vec3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#else
     scalar::kernel_add_vec3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#endif
     return dst;
 }
 
 /// \brief Returns the vector-difference of two 3d vector operands
 ///
-/// \tparam T Type of scalar value used for the 3d-vector operands
-///
-/// This operator implements an element-wise difference of two Vector3 operands
-/// given as input arguments. The internal operator selects the appropriate
-/// "kernel" (just a function) to which to call, depending on whether or not the
-/// library was compiled using SIMD support (i.e. SSE and AVX function
-/// intrinsics will be used to handle the operation).
+/// \tparam T Type of scalar used by both scalar and vector operands
 ///
 /// \param[in] lhs Left-hand-side operand of the vector-sum
 /// \param[in] rhs Right-hand-side operand of the vector-sum
@@ -133,13 +77,7 @@ template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto operator-(const Vector3<T>& lhs, const Vector3<T>& rhs)
     -> Vector3<T> {
     Vector3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_sub_vec3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_sub_vec3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#else
     scalar::kernel_sub_vec3<T>(dst.elements(), lhs.elements(), rhs.elements());
-#endif
     return dst;
 }
 
@@ -147,27 +85,13 @@ LM_INLINE auto operator-(const Vector3<T>& lhs, const Vector3<T>& rhs)
 ///
 /// \tparam T Type of scalar used by both scalar and vector operands
 ///
-/// This operator implements the scalar-vector product of two operands (a scalar
-/// and a vector in that order) given as input arguments. The internal operator
-/// selects the appropriate "kernel" (just a function) to which to call,
-/// depending on whether or not the library was compiled using SIMD support
-/// (i.e. SSE and AVX function intrinsics will be used to handle the operation).
-///
 /// \param[in] scale Scalar value by which to scale the second operand
 /// \param[in] vec Vector in 3d-space which we want to scale
 template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto operator*(double scale, const Vector3<T>& vec) -> Vector3<T> {
     Vector3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_scale_vec3<T>(dst.elements(), static_cast<T>(scale),
-                              vec.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_scale_vec3<T>(dst.elements(), static_cast<T>(scale),
-                              vec.elements());
-#else
     scalar::kernel_scale_vec3<T>(dst.elements(), static_cast<T>(scale),
                                  vec.elements());
-#endif
     return dst;
 }
 
@@ -175,27 +99,13 @@ LM_INLINE auto operator*(double scale, const Vector3<T>& vec) -> Vector3<T> {
 ///
 /// \tparam T Type of scalar used by both vector and scalar operands
 ///
-/// This operator implements the vector-scalar product of two operands (a vector
-/// and a scalar in that order) given as input arguments. The internal operator
-/// selects the appropriate "kernel" (just a function) to which to call,
-/// depending on whether or not the library was compiled using SIMD support
-/// (i.e. SSE and AVX function intrinsics will be used to handle the operation).
-///
 /// \param[in] vec Vector in 3d-space which we want to scale
 /// \param[in] scale Scalar value by which to scale the first operand
 template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto operator*(const Vector3<T>& vec, double scale) -> Vector3<T> {
     Vector3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_scale_vec3<T>(dst.elements(), static_cast<T>(scale),
-                              vec.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_scale_vec3<T>(dst.elements(), static_cast<T>(scale),
-                              vec.elements());
-#else
     scalar::kernel_scale_vec3(dst.elements(), static_cast<T>(scale),
                               vec.elements());
-#endif
     return dst;
 }
 
@@ -203,28 +113,14 @@ LM_INLINE auto operator*(const Vector3<T>& vec, double scale) -> Vector3<T> {
 ///
 /// \tparam T Type of scalar value used by the 3d-vector operands
 ///
-/// This operator implements an element-wise product (Hadamard-Schur product) of
-/// two Vector3 operands given as input arguments. The internal operator selects
-/// the appropriate "kernel" (just a function) to which to call, depending on
-/// whether or not the library was compiled using SIMD support (i.e. SSE and AVX
-/// function intrinsics will be used to handle the operation).
-///
 /// \param[in] lhs Left-hand-side operand of the element-wise product
 /// \param[in] rhs Right-hand-side operand of the element-wise product
 template <typename T, SFINAE_VEC3_GUARD<T> = nullptr>
 LM_INLINE auto operator*(const Vector3<T>& lhs, const Vector3<T>& rhs)
     -> Vector3<T> {
     Vector3<T> dst;
-#if defined(MATH_AVX_ENABLED)
-    avx::kernel_hadamard_vec3<T>(dst.elements(), lhs.elements(),
-                                 rhs.elements());
-#elif defined(MATH_SSE_ENABLED)
-    sse::kernel_hadamard_vec3<T>(dst.elements(), lhs.elements(),
-                                 rhs.elements());
-#else
     scalar::kernel_hadamard_vec3<T>(dst.elements(), lhs.elements(),
                                     rhs.elements());
-#endif
     return dst;
 }
 
@@ -242,15 +138,6 @@ LM_INLINE auto operator-(const Vector3<T>& vec) -> Vector3<T> {
 /// \brief Checks if two given vectors are "equal" (within epsilon margin)
 ///
 /// \tparam T Type of scalar value used by the 3d-vector operands
-///
-/// This operator implements an "np.allclose"-like operation (numpy's allclose
-/// function), checking if the corresponding (x,y,z) entries of both operands
-/// are within a certain margin "epsilon" (pre-defined constant). There was an
-/// "equal"-like SIMD instruction that implements floating point comparisons,
-/// however, we're not using it as single-precision floating point operations
-/// and transformation functions within the library might result in compounding
-/// errors that the user might want to test a small margin of error tuned
-/// appropriately (specially for single-precision floating point types)
 ///
 /// \param[in] lhs Left-hand-side operand of the comparison
 /// \param[in] rhs Right-hand-side operand of the comparison

--- a/include/math/vec3_t_decl.hpp
+++ b/include/math/vec3_t_decl.hpp
@@ -23,13 +23,12 @@ namespace math {
 ///
 /// This is a class that represents a 3d-vector with entries x, y, z of some
 /// scalar floating-point type. Its storage is a buffer of the given scalar
-/// type, and it's aligned accordingly in order to use the aligned versions of
-/// some SIMD instructions (when using either SSE or AVX intrinsics).
+/// type, and contains only the required storage for 3 elements.
 template <typename Scalar_T>
 class Vector3 {
  public:
     /// Number of scalars used in the storage of the vector
-    constexpr static uint32_t BUFFER_SIZE = 4;
+    constexpr static uint32_t BUFFER_SIZE = 3;
     /// Number of scalar dimensions of the vector
     constexpr static uint32_t VECTOR_SIZE = 3;
     /// Number of dimensions of this vector (as in np.array.ndim)
@@ -50,7 +49,6 @@ class Vector3 {
         m_Elements[0] = x_coord;
         m_Elements[1] = x_coord;
         m_Elements[2] = x_coord;
-        m_Elements[3] = 0;
     }
 
     /// Constructs a vector of the form (x, y, y)
@@ -58,7 +56,6 @@ class Vector3 {
         m_Elements[0] = x_coord;
         m_Elements[1] = y_coord;
         m_Elements[2] = y_coord;
-        m_Elements[3] = 0;
     }
 
     /// Constructs a vector of the form (x, y, z)
@@ -66,7 +63,6 @@ class Vector3 {
         m_Elements[0] = x_coord;
         m_Elements[1] = y_coord;
         m_Elements[2] = z_coord;
-        m_Elements[3] = 0;
     }
 
     // cppcheck-suppress noExplicitConstructor
@@ -152,8 +148,8 @@ class Vector3 {
     }
 
  private:
-    /// Storage of the vector's scalars (we pad by 1 due to SIMD usage)
-    BufferType m_Elements = {0, 0, 0, 0};
+    /// Storage of the vector's scalars
+    BufferType m_Elements = {0, 0, 0};
 };
 
 }  // namespace math


### PR DESCRIPTION
# Description
Removes usage of SIMD kernels for both vec3 and mat3, as we'll be using vec3 types without padding. This is related to issue #36, and has all requirements for now to allow usage in OpenGL (when using buffer attributes we'll have no issues as we're using no padding)