### PR TITLE
Feat refactor template args

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,25 +130,17 @@ if(MATH_BUILD_DOCS)
   # cmake-format: off
   # -------------------------------------
   # Setup documentation for our target
-  loco_setup_cppdocs_doxygen(MathCpp
-      DOXYGEN_FILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in
-      DOXYGEN_OUTPUT_DIR ${CMAKE_BINARY_DIR}/docs/Doxygen
-      DOXYGEN_GENERATE_HTML TRUE
-      DOXYGEN_GENERATE_LATEX FALSE
-      DOXYGEN_GENERATE_XML TRUE
-      DOXYGEN_QUIET TRUE)
-
-  #### loco_setup_cppdocs(MathCpp
-  ####   DOXYGEN_FILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in
-  ####   DOXYGEN_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/docs/Doxygen
-  ####   DOXYGEN_GENERATE_HTML FALSE
-  ####   DOXYGEN_GENERATE_LATEX FALSE
-  ####   DOXYGEN_GENERATE_XML TRUE
-  ####   DOXYGEN_QUIET TRUE
-  ####   SPHINX_FILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/conf.py.in
-  ####   SPHINX_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/docs/Sphinx
-  ####   SPHINX_BREATHE_PROJECT MathCpp
-  ####   SPHINX_DOXYGEN_XML_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/docs/Doxygen/xml)
+  loco_setup_cppdocs(MathCpp
+    DOXYGEN_FILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in
+    DOXYGEN_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/docs/Doxygen
+    DOXYGEN_GENERATE_HTML FALSE
+    DOXYGEN_GENERATE_LATEX FALSE
+    DOXYGEN_GENERATE_XML TRUE
+    DOXYGEN_QUIET TRUE
+    SPHINX_FILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/conf.py.in
+    SPHINX_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/docs/Sphinx
+    SPHINX_BREATHE_PROJECT MathCpp
+    SPHINX_DOXYGEN_XML_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/docs/Doxygen/xml)
   # cmake-format: on
 endif()
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = "Math3d"
+project = "MathCpp"
 copyright = "2022, Math3d"
 author = "Anomymous"
 version = "0.4.1"

--- a/include/math/euler_t_decl.hpp
+++ b/include/math/euler_t_decl.hpp
@@ -19,22 +19,22 @@
 
 namespace math {
 
-template <typename Scalar_T>
+template <typename T>
 class Matrix3;
 
-template <typename Scalar_T>
+template <typename T>
 class Matrix4;
 
-template <typename Scalar_T>
+template <typename T>
 class Quaternion;
 
-template <typename Scalar_T>
+template <typename T>
 class Euler {
  public:
-    using Vec3 = Vector3<Scalar_T>;
-    using Mat3 = Matrix3<Scalar_T>;
-    using Mat4 = Matrix4<Scalar_T>;
-    using Quat = Quaternion<Scalar_T>;
+    using Vec3 = Vector3<T>;
+    using Mat3 = Matrix3<T>;
+    using Mat4 = Matrix4<T>;
+    using Quat = Quaternion<T>;
 
     /// Possible ordering (Tait-Bryan angles)
     enum class Order {
@@ -53,11 +53,11 @@ class Euler {
     };
 
     /// \brief Angle of rotation around the X-axis
-    Scalar_T x = static_cast<Scalar_T>(0.0);  // NOLINT
+    T x = static_cast<T>(0.0);  // NOLINT
     /// \brief Angle of rotation around the Y-axis
-    Scalar_T y = static_cast<Scalar_T>(0.0);  // NOLINT
+    T y = static_cast<T>(0.0);  // NOLINT
     /// \brief Angle of rotation around the Z-axis
-    Scalar_T z = static_cast<Scalar_T>(0.0);  // NOLINT
+    T z = static_cast<T>(0.0);  // NOLINT
 
     /// \brief Returns the internal order used for the elemental rotations
     ///
@@ -89,12 +89,12 @@ class Euler {
     Euler() = default;
 
     /// Constructs a set of Euler angles from the given configuration
-    /// \param[in] x Euler angle associated with a rotation around the X axis
-    /// \param[in] y Euler angle associated with a rotation around the Y axis
-    /// \param[in] z Euler angle associated with a rotation around the Z axis
+    /// \param[in] e_x Euler angle associated with a rotation around the X axis
+    /// \param[in] e_y Euler angle associated with a rotation around the Y axis
+    /// \param[in] e_z Euler angle associated with a rotation around the Z axis
     /// \param[in] p_order Order used for the representation
     /// \param[in] p_convention Convention used for the representation
-    explicit Euler(Scalar_T e_x, Scalar_T e_y, Scalar_T e_z, Order p_order = Order::XYZ,
+    explicit Euler(T e_x, T e_y, T e_z, Order p_order = Order::XYZ,
                    Convention p_convention = Convention::INTRINSIC) {
         this->order = p_order;
         this->convention = p_convention;
@@ -127,8 +127,8 @@ class Euler {
 
     /// Constructs a set of Euler angles from the given quaternion
     /// \param[in] quaternion A quaternion given by the user
-    /// \param[in] order Order used for the representation
-    /// \param[in] convention Convention used for the representation
+    /// \param[in] p_order Order used for the representation
+    /// \param[in] p_convention Convention used for the representation
     explicit Euler(const Quat& quaternion, Order p_order = Order::XYZ,
                    Convention p_convention = Convention::INTRINSIC) {
         this->order = p_order;
@@ -139,9 +139,9 @@ class Euler {
     /// Constructs a set of Euler angles from the given axis-angle pair
     /// \param[in] axis The axis of rotation given by the user
     /// \param[in] angle The angle of rotation around the given axis
-    /// \param[in] order Order used for the representation
-    /// \param[in] convention Convention used for the representation
-    explicit Euler(const Vec3& axis, Scalar_T angle, Order p_order = Order::XYZ,
+    /// \param[in] p_order Order used for the representation
+    /// \param[in] p_convention Convention used for the representation
+    explicit Euler(const Vec3& axis, T angle, Order p_order = Order::XYZ,
                    Convention p_convention = Convention::INTRINSIC) {
         this->order = p_order;
         this->convention = p_convention;
@@ -158,7 +158,7 @@ class Euler {
     auto setFromQuaternion(const Quat& quaternion) -> void;
 
     /// Updates this set of Euler angles with the given axis-angle pair
-    auto setFromAxisAngle(const Vec3& axis, Scalar_T angle) -> void;
+    auto setFromAxisAngle(const Vec3& axis, T angle) -> void;
 };
 
 }  // namespace math

--- a/include/math/mat2_t_decl.hpp
+++ b/include/math/mat2_t_decl.hpp
@@ -21,14 +21,14 @@ namespace math {
 ///
 /// \brief Class representation of a 2 by 2 matrix of real-valued entries
 ///
-/// \tparam Scalar_T Type of scalar value used for the entries of the matrix
+/// \tparam T Type of scalar value used for the entries of the matrix
 ///
 /// This is a class that represents 2x2 matrices with real-valued entries. The
 /// internal data is stored as the columns of the matrix using 2d vectors of the
 /// same scalar type. The resulting storage is column major and aligned in a way
 /// that allows the use of aligned versions of some SIMD instructions (when
 /// using either SSE or AVX instrinsics).
-template <typename Scalar_T>
+template <typename T>
 class Matrix2 {
  public:
     /// Number of scalars used for the storage of this matrix
@@ -39,19 +39,19 @@ class Matrix2 {
     static constexpr uint32_t MATRIX_NDIM = 2;
 
     /// Typename of the matrix
-    using Type = Matrix2<Scalar_T>;
+    using Type = Matrix2<T>;
     /// Typename of the scalar used for the matrix entries (float, double, etc.)
-    using ElementType = Scalar_T;
+    using ElementType = T;
     /// Typename of the internal storage used by the matrix
-    using BufferType = std::array<Vector2<Scalar_T>, MATRIX_SIZE>;
+    using BufferType = std::array<Vector2<T>, MATRIX_SIZE>;
     /// Typename of the columns of the matrix
-    using ColumnType = Vector2<Scalar_T>;
+    using ColumnType = Vector2<T>;
 
     /// Creates a zero-initialized matrix
     Matrix2() = default;
 
     /// Creates a matrix using the given scalars for its entries
-    explicit Matrix2(Scalar_T x00, Scalar_T x01, Scalar_T x10, Scalar_T x11) {
+    explicit Matrix2(T x00, T x01, T x10, T x11) {
         m_Elements[0][0] = x00;
         m_Elements[1][0] = x01;
 
@@ -59,7 +59,7 @@ class Matrix2 {
         m_Elements[1][1] = x11;
     }
 
-    explicit Matrix2(Scalar_T x00, Scalar_T x11) {
+    explicit Matrix2(T x00, T x11) {
         m_Elements[0][0] = x00;
         m_Elements[1][1] = x11;
     }
@@ -76,10 +76,10 @@ class Matrix2 {
     auto elements() const -> const BufferType& { return m_Elements; }
 
     /// Returns a pointer to the data of the underlying storage in use
-    auto data() -> Scalar_T* { return m_Elements[0].data(); }
+    auto data() -> T* { return m_Elements[0].data(); }
 
     /// Reeturns a const-pointer to the data of the underlying storage in use
-    auto data() const -> const Scalar_T* { return m_Elements[0].data(); }
+    auto data() const -> const T* { return m_Elements[0].data(); }
 
     /// Gets a mutable reference to the column requested by the given index
     auto operator[](uint32_t col_index) -> ColumnType& {
@@ -92,18 +92,17 @@ class Matrix2 {
     }
 
     /// Gets a mutable reference to the requested matrix entry
-    auto operator()(uint32_t row_index, uint32_t col_index) -> Scalar_T& {
+    auto operator()(uint32_t row_index, uint32_t col_index) -> T& {
         return m_Elements[col_index][row_index];
     }
 
     /// Gets an unmutable reference to the requested matrix entry
-    auto operator()(uint32_t row_index, uint32_t col_index) const
-        -> const Scalar_T& {
+    auto operator()(uint32_t row_index, uint32_t col_index) const -> const T& {
         return m_Elements[col_index][row_index];
     }
 
     /// Returns a comma-initializer to construct the matrix via its coefficients
-    auto operator<<(Scalar_T coeff) -> MatCommaInitializer<Type> {
+    auto operator<<(T coeff) -> MatCommaInitializer<Type> {
         return MatCommaInitializer<Type>(*this, coeff);
     }
 
@@ -121,19 +120,22 @@ class Matrix2 {
     }
 
     /// Creates a rotation matrix for the given angle
-    static auto Rotation(Scalar_T angle) -> Matrix2<Scalar_T>;
+    static auto Rotation(T angle) -> Matrix2<T>;
 
     /// Creates a scale matrix with the two given scale parameters
-    static auto Scale(Scalar_T scale_x, Scalar_T scale_y) -> Matrix2<Scalar_T>;
+    /// \param[in] scale_x The value for the scale in the x component
+    /// \param[in] scale_y The value for the scale in the y component
+    static auto Scale(T scale_x, T scale_y) -> Matrix2<T>;
 
     /// Creates a scale matrix given scale parameters as a vec-2
-    static auto Scale(const Vector2<Scalar_T>& scale) -> Matrix2<Scalar_T>;
+    /// \param[in] scale A vec2 with both values for the scales
+    static auto Scale(const Vector2<T>& scale) -> Matrix2<T>;
 
     /// Returns a 4x4 identity matrix of the current scalar type
-    static auto Identity() -> Matrix2<Scalar_T>;
+    static auto Identity() -> Matrix2<T>;
 
     /// Returns a 4x4 zero matrix of the current scalar type
-    static auto Zeros() -> Matrix2<Scalar_T>;
+    static auto Zeros() -> Matrix2<T>;
 
     /// Returns the number of rows
     static constexpr auto rows() -> uint32_t { return MATRIX_SIZE; }

--- a/include/math/mat3_t_decl.hpp
+++ b/include/math/mat3_t_decl.hpp
@@ -19,13 +19,13 @@
 
 namespace math {
 
-template <typename Scalar_T>
+template <typename T>
 class Matrix4;
 
-template <typename Scalar_T>
+template <typename T>
 class Quaternion;
 
-template <typename Scalar_T>
+template <typename T>
 class Euler;
 
 }  // namespace math
@@ -36,12 +36,12 @@ namespace math {
 ///
 /// \brief Class representation of a 3 by 3 matrix of real-valued entries
 ///
-/// \tparam Scalar_T Type of scalar value used for the entries of the matrix
+/// \tparam T Type of scalar value used for the entries of the matrix
 ///
 /// This is a class that represents 3x3 matrices with real-valued entries. The
 /// internal data is stored as the columns of the matrix using 3d vectors of the
 /// same scalar type, thus using a column major order.
-template <typename Scalar_T>
+template <typename T>
 class Matrix3 {
  public:
     /// Number of scalars used for the storage of this matrix
@@ -52,27 +52,27 @@ class Matrix3 {
     static constexpr uint32_t MATRIX_NDIM = 2;
 
     /// Typename of the matrix
-    using Type = Matrix3<Scalar_T>;
+    using Type = Matrix3<T>;
     /// Typename of the scalar used for the matrix entries (float, double, etc.)
-    using ElementType = Scalar_T;
+    using ElementType = T;
     /// Typename of the internal storage used by the matrix
-    using BufferType = std::array<Vector3<Scalar_T>, MATRIX_SIZE>;
+    using BufferType = std::array<Vector3<T>, MATRIX_SIZE>;
     /// Typename of the columns of the matrix
-    using ColumnType = Vector3<Scalar_T>;
+    using ColumnType = Vector3<T>;
 
     // Some related types
-    using Vec3 = Vector3<Scalar_T>;
-    using Mat4 = Matrix4<Scalar_T>;
-    using Quat = Quaternion<Scalar_T>;
+    using Vec3 = Vector3<T>;
+    using Mat4 = Matrix4<T>;
+    using Quat = Quaternion<T>;
 
     /// Creates a zero-initialized matrix
     Matrix3() = default;
 
     // clang-format off
     /// Creates a matrix using the given scalars for its entries
-    explicit Matrix3(Scalar_T x00, Scalar_T x01, Scalar_T x02,
-                     Scalar_T x10, Scalar_T x11, Scalar_T x12,
-                     Scalar_T x20, Scalar_T x21, Scalar_T x22) {
+    explicit Matrix3(T x00, T x01, T x02,
+                     T x10, T x11, T x12,
+                     T x20, T x21, T x22) {
         // First row
         m_Elements[0][0] = x00;
         m_Elements[1][0] = x01;
@@ -91,7 +91,7 @@ class Matrix3 {
     // clang-format on
 
     /// \brief Creates a diagonal matrix from some given diagonal entries
-    explicit Matrix3(Scalar_T x00, Scalar_T x11, Scalar_T x22) {
+    explicit Matrix3(T x00, T x11, T x22) {
         m_Elements[0][0] = x00;
         m_Elements[1][1] = x11;
         m_Elements[2][2] = x22;
@@ -109,7 +109,7 @@ class Matrix3 {
     explicit Matrix3(const Quat& quaternion) { setFromQuaternion(quaternion); }
 
     /// \brief Creates a 3x3 rotation matrix from a given set of Euler angles
-    explicit Matrix3(const Euler<Scalar_T>& euler) { setFromEuler(euler); }
+    explicit Matrix3(const Euler<T>& euler) { setFromEuler(euler); }
 
     /// \brief Creates a 3x3 rotation matrix from a given 4x4 transform matrix
     explicit Matrix3(const Mat4& transform) { setFromTransform(transform); }
@@ -118,7 +118,7 @@ class Matrix3 {
     auto setFromQuaternion(const Quat& quaternion) -> void;
 
     /// \brief Updates this rotation matrix from a given set of Euler angles
-    auto setFromEuler(const Euler<Scalar_T>& euler) -> void;
+    auto setFromEuler(const Euler<T>& euler) -> void;
 
     /// \brief Updates this rotation matrix from a given 4x4 transform matrix
     auto setFromTransform(const Mat4& transform) -> void;
@@ -130,10 +130,10 @@ class Matrix3 {
     auto elements() const -> const BufferType& { return m_Elements; }
 
     /// Returns a pointer to the data of the underlying storage in use
-    auto data() -> Scalar_T* { return m_Elements[0].data(); }
+    auto data() -> T* { return m_Elements[0].data(); }
 
     /// Reeturns a const-pointer to the data of the underlying storage in use
-    auto data() const -> const Scalar_T* { return m_Elements[0].data(); }
+    auto data() const -> const T* { return m_Elements[0].data(); }
 
     /// Gets a mutable reference to the column requested by the given index
     auto operator[](uint32_t col_index) -> ColumnType& {
@@ -146,13 +146,12 @@ class Matrix3 {
     }
 
     /// Gets a mutable reference to the requested matrix entry
-    auto operator()(uint32_t row_index, uint32_t col_index) -> Scalar_T& {
+    auto operator()(uint32_t row_index, uint32_t col_index) -> T& {
         return m_Elements[col_index][row_index];
     }
 
     /// Gets an unmutable reference to the requested matrix entry
-    auto operator()(uint32_t row_index, uint32_t col_index) const
-        -> const Scalar_T& {
+    auto operator()(uint32_t row_index, uint32_t col_index) const -> const T& {
         return m_Elements[col_index][row_index];
     }
 
@@ -167,7 +166,7 @@ class Matrix3 {
     LM_INLINE auto operator*(const Vec3& rhs) -> Vec3;
 
     /// Returns a comma-initializer to construct the matrix via its coefficients
-    auto operator<<(Scalar_T coeff) -> MatCommaInitializer<Type> {
+    auto operator<<(T coeff) -> MatCommaInitializer<Type> {
         return MatCommaInitializer<Type>(*this, coeff);
     }
 
@@ -187,26 +186,25 @@ class Matrix3 {
     }
 
     /// Creates a rotation matrix for the given angle around the X-axis
-    static auto RotationX(Scalar_T angle) -> Matrix3<Scalar_T>;
+    static auto RotationX(T angle) -> Matrix3<T>;
 
     /// Creates a rotation matrix for the given angle around the Y-axis
-    static auto RotationY(Scalar_T angle) -> Matrix3<Scalar_T>;
+    static auto RotationY(T angle) -> Matrix3<T>;
 
     /// Creates a rotation matrix for the given angle around the Z-axis
-    static auto RotationZ(Scalar_T angle) -> Matrix3<Scalar_T>;
+    static auto RotationZ(T angle) -> Matrix3<T>;
 
     /// Creates a scale matrix for the given separate scale arguments
-    static auto Scale(Scalar_T scale_x, Scalar_T scale_y, Scalar_T scale_z)
-        -> Matrix3<Scalar_T>;
+    static auto Scale(T scale_x, T scale_y, T scale_z) -> Matrix3<T>;
 
     /// Creates a scale matrix for the given scale arguments given as a vec-3
-    static auto Scale(const Vector3<Scalar_T>& scale) -> Matrix3<Scalar_T>;
+    static auto Scale(const Vector3<T>& scale) -> Matrix3<T>;
 
     /// Creates an Identity matrix
-    static auto Identity() -> Matrix3<Scalar_T>;
+    static auto Identity() -> Matrix3<T>;
 
     /// Creates a Zero matrix
-    static auto Zeros() -> Matrix3<Scalar_T>;
+    static auto Zeros() -> Matrix3<T>;
 
     /// Returns the number of rows
     static constexpr auto rows() -> uint32_t { return MATRIX_SIZE; }

--- a/include/math/mat4_t_decl.hpp
+++ b/include/math/mat4_t_decl.hpp
@@ -21,13 +21,13 @@
 
 namespace math {
 
-template <typename Scalar_T>
+template <typename T>
 class Matrix3;
 
-template <typename Scalar_T>
+template <typename T>
 class Euler;
 
-template <typename Scalar_T>
+template <typename T>
 class Quaternion;
 
 }  // namespace math
@@ -38,14 +38,14 @@ namespace math {
 ///
 /// \brief Class representation of a 4 by 4 matrix of real-valued entries
 ///
-/// \tparam Scalar_T Type of scalar value used for the entries of the matrix
+/// \tparam T Type of scalar value used for the entries of the matrix
 ///
 /// This is a class that represents 4x4 matrices with real-valued entries. The
 /// internal data is stored as the columns of the matrix using 4d vectors of the
 /// same scalar type. The resulting storage is column major and aligned in a way
 /// that allows the use of aligned versions of some SIMD instructions (when
 /// using either SSE or AVX instrinsics).
-template <typename Scalar_T>
+template <typename T>
 class Matrix4 {
  public:
     /// Number of scalars used in the storage of the matrix
@@ -56,28 +56,26 @@ class Matrix4 {
     static constexpr uint32_t MATRIX_NDIM = 2;
 
     /// Typename of the matrix
-    using Type = Matrix4<Scalar_T>;
+    using Type = Matrix4<T>;
     /// Typename of the scalar used for the matrix entries (float, double, etc.)
-    using ElementType = Scalar_T;
+    using ElementType = T;
     /// Typename of the internal storage used by the matrix
-    using BufferType = std::array<Vector4<Scalar_T>, MATRIX_SIZE>;
+    using BufferType = std::array<Vector4<T>, MATRIX_SIZE>;
     /// Typename of the columns of the matrix
-    using ColumnType = Vector4<Scalar_T>;
+    using ColumnType = Vector4<T>;
 
     // Some related types
-    using Vec3 = Vector3<Scalar_T>;
-    using Vec4 = Vector4<Scalar_T>;
-    using Mat3 = Matrix3<Scalar_T>;
-    using Quat = Quaternion<Scalar_T>;
+    using Vec3 = Vector3<T>;
+    using Vec4 = Vector4<T>;
+    using Mat3 = Matrix3<T>;
+    using Quat = Quaternion<T>;
 
     /// Creates a zero-initialized matrix
     Matrix4() = default;
 
     /// Creates a matrix using the given scalars for its entries
-    explicit Matrix4(Scalar_T x00, Scalar_T x01, Scalar_T x02, Scalar_T x03,
-                     Scalar_T x10, Scalar_T x11, Scalar_T x12, Scalar_T x13,
-                     Scalar_T x20, Scalar_T x21, Scalar_T x22, Scalar_T x23,
-                     Scalar_T x30, Scalar_T x31, Scalar_T x32, Scalar_T x33) {
+    explicit Matrix4(T x00, T x01, T x02, T x03, T x10, T x11, T x12, T x13,
+                     T x20, T x21, T x22, T x23, T x30, T x31, T x32, T x33) {
         // Row-0
         m_Elements[0][0] = x00;
         m_Elements[1][0] = x01;
@@ -104,7 +102,7 @@ class Matrix4 {
     }
 
     /// Creates a diagonal matrix using the given diagonal elements
-    explicit Matrix4(Scalar_T x00, Scalar_T x11, Scalar_T x22, Scalar_T x33) {
+    explicit Matrix4(T x00, T x11, T x22, T x33) {
         m_Elements[0][0] = x00;
         m_Elements[1][1] = x11;
         m_Elements[2][2] = x22;
@@ -139,7 +137,7 @@ class Matrix4 {
     /// Constructs a transform matrix given its world position and orientation
     /// \param[in] position The position part of the transform in world space
     /// \param[in] euler A set of euler angles representing orientation
-    explicit Matrix4(const Vec3& position, const Euler<Scalar_T>& euler) {
+    explicit Matrix4(const Vec3& position, const Euler<T>& euler) {
         setPosition(position);
         setRotation(euler);
     }
@@ -151,7 +149,7 @@ class Matrix4 {
     auto setRotation(const Quat& quat) -> void;
 
     /// Sets the rotation part of this transform from given euler angles
-    auto setRotation(const Euler<Scalar_T>& euler) -> void;
+    auto setRotation(const Euler<T>& euler) -> void;
 
     /// Sets the rotation part of this transform from a 3x3 rotation matrix
     auto setRotation(const Mat3& mat) -> void;
@@ -163,10 +161,10 @@ class Matrix4 {
     auto elements() const -> const BufferType& { return m_Elements; }
 
     /// Returns a pointer to the data of the underlying storage in use
-    auto data() -> Scalar_T* { return m_Elements[0].data(); }
+    auto data() -> T* { return m_Elements[0].data(); }
 
     /// Reeturns a const-pointer to the data of the underlying storage in use
-    auto data() const -> const Scalar_T* { return m_Elements[0].data(); }
+    auto data() const -> const T* { return m_Elements[0].data(); }
 
     /// Gets a mutable reference to the column requested by the given index
     auto operator[](uint32_t col_index) -> ColumnType& {
@@ -179,18 +177,17 @@ class Matrix4 {
     }
 
     /// Gets a mutable reference to the requested matrix entry
-    auto operator()(uint32_t row_index, uint32_t col_index) -> Scalar_T& {
+    auto operator()(uint32_t row_index, uint32_t col_index) -> T& {
         return m_Elements[col_index][row_index];
     }
 
     /// Gets an unmutable reference to the requested matrix entry
-    auto operator()(uint32_t row_index, uint32_t col_index) const
-        -> const Scalar_T& {
+    auto operator()(uint32_t row_index, uint32_t col_index) const -> const T& {
         return m_Elements[col_index][row_index];
     }
 
     /// Returns a comma-initializer to construct the matrix via its coefficients
-    auto operator<<(Scalar_T coeff) -> MatCommaInitializer<Type> {
+    auto operator<<(T coeff) -> MatCommaInitializer<Type> {
         return MatCommaInitializer<Type>(*this, coeff);
     }
 
@@ -216,43 +213,38 @@ class Matrix4 {
     }
 
     /// Creates a rotation matrix for the given angle around the X-axis
-    static auto RotationX(Scalar_T angle) -> Matrix4<Scalar_T>;
+    static auto RotationX(T angle) -> Matrix4<T>;
 
     /// Creates a rotation matrix for the given angle around the Y-axis
-    static auto RotationY(Scalar_T angle) -> Matrix4<Scalar_T>;
+    static auto RotationY(T angle) -> Matrix4<T>;
 
     /// Creates a rotation matrix for the given angle around the Z-axis
-    static auto RotationZ(Scalar_T angle) -> Matrix4<Scalar_T>;
+    static auto RotationZ(T angle) -> Matrix4<T>;
 
     /// Creates a scale matrix for the given separate scale arguments
-    static auto Scale(Scalar_T scale_x, Scalar_T scale_y, Scalar_T scale_z)
-        -> Matrix4<Scalar_T>;
+    static auto Scale(T scale_x, T scale_y, T scale_z) -> Matrix4<T>;
 
     /// Creates a scale matrix for the given scale arguments given as a vec3
-    static auto Scale(const Vector3<Scalar_T>& scale) -> Matrix4<Scalar_T>;
+    static auto Scale(const Vector3<T>& scale) -> Matrix4<T>;
 
     /// Creates a translation matrix from the given translation given as a vec3
-    static auto Translation(const Vector3<Scalar_T>& position)
-        -> Matrix4<Scalar_T>;
+    static auto Translation(const Vector3<T>& position) -> Matrix4<T>;
 
     /// Creates a perspective projection matrix from the given configuration
-    static auto Perspective(Scalar_T fov, Scalar_T aspect, Scalar_T near,
-                            Scalar_T far) -> Matrix4<Scalar_T>;
+    static auto Perspective(T fov, T aspect, T near, T far) -> Matrix4<T>;
 
     /// Creates a perspective projection matrix from the frustum sizes
-    static auto Perspective(Scalar_T left, Scalar_T right, Scalar_T top,
-                            Scalar_T bottom, Scalar_T near, Scalar_T far)
-        -> Matrix4<Scalar_T>;
+    static auto Perspective(T left, T right, T top, T bottom, T near, T far)
+        -> Matrix4<T>;
 
     /// Creates a orthographic projection matrix from the given configuration
-    static auto Ortho(Scalar_T width, Scalar_T height, Scalar_T near,
-                      Scalar_T far) -> Matrix4<Scalar_T>;
+    static auto Ortho(T width, T height, T near, T far) -> Matrix4<T>;
 
     /// Returns a 4x4 identity matrix of the current scalar type
-    static auto Identity() -> Matrix4<Scalar_T>;
+    static auto Identity() -> Matrix4<T>;
 
     /// Returns a 4x4 zero matrix of the current scalar type
-    static auto Zeros() -> Matrix4<Scalar_T>;
+    static auto Zeros() -> Matrix4<T>;
 
     /// Returns the number of rows
     static constexpr auto rows() -> uint32_t { return MATRIX_SIZE; }

--- a/include/math/pose3d_t_decl.hpp
+++ b/include/math/pose3d_t_decl.hpp
@@ -12,26 +12,26 @@
 #include <math/euler_t_decl.hpp>
 
 namespace math {
-template <typename Scalar_T>
+template <typename T>
 class Matrix3;
 
-template <typename Scalar_T>
+template <typename T>
 class Euler;
 
-template <typename Scalar_T>
+template <typename T>
 class Quaternion;
 }  // namespace math
 
 namespace math {
 
-template <typename Scalar_T>
+template <typename T>
 class Pose3d {
  public:
-    using Vec3 = ::math::Vector3<Scalar_T>;
-    using Vec4 = ::math::Vector4<Scalar_T>;
-    using Quat = ::math::Quaternion<Scalar_T>;
-    using Mat3 = ::math::Matrix3<Scalar_T>;
-    using Mat4 = ::math::Matrix4<Scalar_T>;
+    using Vec3 = ::math::Vector3<T>;
+    using Vec4 = ::math::Vector4<T>;
+    using Quat = ::math::Quaternion<T>;
+    using Mat3 = ::math::Matrix3<T>;
+    using Mat4 = ::math::Matrix4<T>;
 
     /// The position component of this pose
     Vec3 position;
@@ -42,7 +42,7 @@ class Pose3d {
 
     explicit Pose3d(const Vec3& pos, const Quat& quat);
 
-    explicit Pose3d(const Vec3& pos, const Euler<Scalar_T>& euler);
+    explicit Pose3d(const Vec3& pos, const Euler<T>& euler);
 
     explicit Pose3d(const Vec3& pos, const Mat3& mat);
 
@@ -52,14 +52,13 @@ class Pose3d {
     LM_INLINE auto apply(const Vec3& rhs) const -> Vec3;
 
     /// Returns the inverse of this pose
-    LM_INLINE auto inverse() const -> Pose3d<Scalar_T>;
+    LM_INLINE auto inverse() const -> Pose3d<T>;
 
     /// Returns a 4x4 matrix equivalent to this pose
     LM_INLINE auto toMatrix() const -> Mat4;
 
     /// Composes the given pose with this pose
-    LM_INLINE auto operator*(const Pose3d<Scalar_T>& rhs) const
-        -> Pose3d<Scalar_T>;
+    LM_INLINE auto operator*(const Pose3d<T>& rhs) const -> Pose3d<T>;
 
     /// Applies this transform to the given vector
     LM_INLINE auto operator*(const Vec3& rhs) const -> Vec3;

--- a/include/math/quat_t_decl.hpp
+++ b/include/math/quat_t_decl.hpp
@@ -19,20 +19,20 @@
 
 namespace math {
 
-template <typename Scalar_T>
+template <typename T>
 class Matrix3;
 
-template <typename Scalar_T>
+template <typename T>
 class Matrix4;
 
-template <typename Scalar_T>
+template <typename T>
 class Euler;
 
 }  // namespace math
 
 namespace math {
 
-template <typename Scalar_T>
+template <typename T>
 class Quaternion {
  public:
     /// Number of scalar dimensions of the quaternion
@@ -40,30 +40,30 @@ class Quaternion {
     /// Number of scalars used in the storage of the vector
     constexpr static uint32_t BUFFER_COUNT = 4;
     /// Number of bytes allocated for the buffer of this quaternion
-    constexpr static uint32_t BUFFER_SIZE = sizeof(Scalar_T) * BUFFER_COUNT;
+    constexpr static uint32_t BUFFER_SIZE = sizeof(T) * BUFFER_COUNT;
 
     /// Typename of the vector
-    using Type = Quaternion<Scalar_T>;
+    using Type = Quaternion<T>;
     /// Typename of the scalar used for the vector (float32, float64, etc.)
-    using ElementType = Scalar_T;
+    using ElementType = T;
     /// Typename of the internal storage used for the vector
-    using BufferType = std::array<Scalar_T, BUFFER_COUNT>;
+    using BufferType = std::array<T, BUFFER_COUNT>;
 
     // Some related types
-    using Vec3 = Vector3<Scalar_T>;
-    using Mat3 = Matrix3<Scalar_T>;
-    using Mat4 = Matrix4<Scalar_T>;
+    using Vec3 = Vector3<T>;
+    using Mat3 = Matrix3<T>;
+    using Mat4 = Matrix4<T>;
 
     /// Constructs a zero-initialized vector
     Quaternion() = default;
 
     /// Constructs a real-valued quaternion
     /// \param real Real-value part of the quaternion
-    explicit Quaternion(Scalar_T real) {
+    explicit Quaternion(T real) {
         m_Elements[0] = real;
-        m_Elements[1] = static_cast<Scalar_T>(0.0F);
-        m_Elements[2] = static_cast<Scalar_T>(0.0F);
-        m_Elements[3] = static_cast<Scalar_T>(0.0F);
+        m_Elements[1] = static_cast<T>(0.0F);
+        m_Elements[2] = static_cast<T>(0.0F);
+        m_Elements[3] = static_cast<T>(0.0F);
     }
 
     /// Constructs a quaternion given its 4 components
@@ -71,8 +71,7 @@ class Quaternion {
     /// \param y_val Value of the second imaginary component
     /// \param z_val Value of the third imaginary component
     /// \param w_val Value of the real-valued component
-    explicit Quaternion(Scalar_T w_val, Scalar_T x_val, Scalar_T y_val,
-                        Scalar_T z_val) {
+    explicit Quaternion(T w_val, T x_val, T y_val, T z_val) {
         m_Elements[0] = w_val;
         m_Elements[1] = x_val;
         m_Elements[2] = y_val;
@@ -84,25 +83,25 @@ class Quaternion {
     explicit Quaternion(const Mat3& matrix) { setFromRotationMatrix(matrix); }
 
     /// Constructs a quaternion given a 4x4 transformation matrix
-    /// \param[in] matrix A 4x4 transformation matrix given by the user
+    /// \param[in] transform A 4x4 transformation matrix given by the user
     explicit Quaternion(const Mat4& transform) { setFromTransform(transform); }
 
     /// Constructs a quaternion given a set of Euler angles
     /// \param[in] euler A set of euler angles describing the same rotation
-    explicit Quaternion(const Euler<Scalar_T>& euler) { setFromEuler(euler); }
+    explicit Quaternion(const Euler<T>& euler) { setFromEuler(euler); }
 
     /// Constructs a quaternion given an axis-angle pair
     /// \param[in] axis A vector representing the rotation axis
     /// \param[in] angle The angle by which to rotate around the given axis
-    explicit Quaternion(const Vec3& axis, Scalar_T angle) {
+    explicit Quaternion(const Vec3& axis, T angle) {
         setFromAxisAngle(axis, angle);
     }
 
     // cppcheck-suppress noExplicitConstructor
     /// Constructs a quaternion from a given list of the form {x, y, z, w}
-    Quaternion(const std::initializer_list<Scalar_T>& values) {
+    Quaternion(const std::initializer_list<T>& values) {
         // Complain in case we don't receive exactly 4 values
-        assert(values.size() == Quaternion<Scalar_T>::QUAT_SIZE);
+        assert(values.size() == Quaternion<T>::QUAT_SIZE);
         // Just copy the whole data from the initializer list
         std::copy(values.begin(), values.end(), m_Elements.data());
     }
@@ -114,16 +113,16 @@ class Quaternion {
     auto setFromTransform(const Mat4& transform) -> void;
 
     /// \brief Updates this quaternion with a given set of Euler angles
-    auto setFromEuler(const Euler<Scalar_T>& euler) -> void;
+    auto setFromEuler(const Euler<T>& euler) -> void;
 
     /// \brief Updates this quaternion with a given axes-angle pair
-    auto setFromAxisAngle(const Vec3& axis, Scalar_T angle) -> void;
+    auto setFromAxisAngle(const Vec3& axis, T angle) -> void;
 
     /// \brief Returns the conjugate of this quaternion
-    auto conjugate() const -> Quaternion<Scalar_T>;
+    auto conjugate() const -> Quaternion<T>;
 
     /// \brief Returns the inverse of this quaternion
-    auto inverse() const -> Quaternion<Scalar_T>;
+    auto inverse() const -> Quaternion<T>;
 
     /// \brief Rotates the given vector using this quaternion
     auto rotate(const Vec3& vec) const -> Vec3;
@@ -132,37 +131,37 @@ class Quaternion {
     auto normalize() -> void;
 
     /// \brief Returns a normalized version of a given quaternnion
-    auto normalized() const -> Quaternion<Scalar_T>;
+    auto normalized() const -> Quaternion<T>;
 
     /// \brief Returns the square of the norm of this quaternion
-    auto lengthSquare() const -> Scalar_T;
+    auto lengthSquare() const -> T;
 
     /// \brief Returns the norm of this quaternion
-    auto length() const -> Scalar_T;
+    auto length() const -> T;
 
     /// Returns a mutable reference to the real w-component
-    auto w() -> Scalar_T& { return m_Elements[0]; }
+    auto w() -> T& { return m_Elements[0]; }
 
     /// Returns a mutable reference to the imaginary x-component
-    auto x() -> Scalar_T& { return m_Elements[1]; }
+    auto x() -> T& { return m_Elements[1]; }
 
     /// Returns a mutable reference to the imaginary y-component
-    auto y() -> Scalar_T& { return m_Elements[2]; }
+    auto y() -> T& { return m_Elements[2]; }
 
     /// Returns a mutable reference to the imaginary z-component
-    auto z() -> Scalar_T& { return m_Elements[3]; }
+    auto z() -> T& { return m_Elements[3]; }
 
     /// Returns an unmutable reference to the real w-component
-    auto w() const -> const Scalar_T& { return m_Elements[0]; }
+    auto w() const -> const T& { return m_Elements[0]; }
 
     /// Returns an unmutable reference to the imaginary x-component
-    auto x() const -> const Scalar_T& { return m_Elements[1]; }
+    auto x() const -> const T& { return m_Elements[1]; }
 
     /// Returns an unmutable reference to the imaginary y-component
-    auto y() const -> const Scalar_T& { return m_Elements[2]; }
+    auto y() const -> const T& { return m_Elements[2]; }
 
     /// Returns an unmutable reference to the imaginary z-component
-    auto z() const -> const Scalar_T& { return m_Elements[3]; }
+    auto z() const -> const T& { return m_Elements[3]; }
 
     /// Returns a mutable reference to the storage of the quaternion
     auto elements() -> BufferType& { return m_Elements; }
@@ -171,16 +170,16 @@ class Quaternion {
     auto elements() const -> const BufferType& { return m_Elements; }
 
     /// Returns a pointer to the data of the underlying storage in use
-    auto data() -> Scalar_T* { return m_Elements.data(); }
+    auto data() -> T* { return m_Elements.data(); }
 
     /// Reeturns a const-pointer to the data of the underlying storage in use
-    auto data() const -> const Scalar_T* { return m_Elements.data(); }
+    auto data() const -> const T* { return m_Elements.data(); }
 
     /// Returns a mutable reference to the requested entry of the quaternion
-    auto operator[](uint32_t index) -> Scalar_T& { return m_Elements[index]; }
+    auto operator[](uint32_t index) -> T& { return m_Elements[index]; }
 
     /// Returns an unmutable reference to the requested entry of the quaternion
-    auto operator[](uint32_t index) const -> const Scalar_T& {
+    auto operator[](uint32_t index) const -> const T& {
         return m_Elements[index];
     }
 
@@ -201,13 +200,13 @@ class Quaternion {
     }
 
     /// Returns the quaternion associated with the given rotation around x-axis
-    static auto RotationX(Scalar_T angle) -> Quaternion<Scalar_T>;
+    static auto RotationX(T angle) -> Quaternion<T>;
 
     /// Returns the quaternion associated with the given rotation around y-axis
-    static auto RotationY(Scalar_T angle) -> Quaternion<Scalar_T>;
+    static auto RotationY(T angle) -> Quaternion<T>;
 
     /// Returns the quaternion associated with the given rotation around z-axis
-    static auto RotationZ(Scalar_T angle) -> Quaternion<Scalar_T>;
+    static auto RotationZ(T angle) -> Quaternion<T>;
 
  private:
     /// Storage of the quaternion's entries in   (w, x, y, z) order

--- a/include/math/utils/spherical_coordinates.hpp
+++ b/include/math/utils/spherical_coordinates.hpp
@@ -21,33 +21,33 @@
 
 namespace math {
 
-template <typename Scalar_T>
+template <typename T>
 class SphericalCoords {
  public:
     SphericalCoords() = default;
 
-    explicit SphericalCoords(Scalar_T p_rho, Scalar_T p_theta, Scalar_T p_phi)
+    explicit SphericalCoords(T p_rho, T p_theta, T p_phi)
         : rho(p_rho), theta(p_theta), phi(p_phi) {}
 
-    auto SetFromCartesian(const Vector3<Scalar_T>& vec) -> void {
+    auto SetFromCartesian(const Vector3<T>& vec) -> void {
         SetFromCartesian(vec.x(), vec.y(), vec.z());
     }
 
-    auto SetFromCartesian(Scalar_T x, Scalar_T y, Scalar_T z) -> void {
+    auto SetFromCartesian(T x, T y, T z) -> void {
         rho = std::sqrt(x * x + y * y + z * z);
-        constexpr auto EPS_RADIUS = static_cast<Scalar_T>(1e-10);
+        constexpr auto EPS_RADIUS = static_cast<T>(1e-10);
         if (rho < EPS_RADIUS) {
-            theta = static_cast<Scalar_T>(0.0);
-            phi = static_cast<Scalar_T>(0.0);
+            theta = static_cast<T>(0.0);
+            phi = static_cast<T>(0.0);
         } else {
             theta = std::atan2(y, x);
-            constexpr auto MIN_RATIO = static_cast<Scalar_T>(-1.0);
-            constexpr auto MAX_RATIO = static_cast<Scalar_T>(1.0);
+            constexpr auto MIN_RATIO = static_cast<T>(-1.0);
+            constexpr auto MAX_RATIO = static_cast<T>(1.0);
             phi = std::acos(CLAMP(z / rho, MIN_RATIO, MAX_RATIO));
         }
     }
 
-    auto GetCartesian() const -> Vector3<Scalar_T> {
+    auto GetCartesian() const -> Vector3<T> {
         const auto sin_theta = std::sin(theta);  // NOLINT
         const auto cos_theta = std::cos(theta);  // NOLINT
         const auto sin_phi = std::sin(phi);      // NOLINT
@@ -62,17 +62,17 @@ class SphericalCoords {
 
     auto MakeSafe() -> void {
         // Restrict phi to be between EPS and PI-EPS
-        constexpr auto MIN_PHI = static_cast<Scalar_T>(math::EPS);
-        constexpr auto MAX_PHI = static_cast<Scalar_T>(math::PI - math::EPS);
+        constexpr auto MIN_PHI = static_cast<T>(math::EPS);
+        constexpr auto MAX_PHI = static_cast<T>(math::PI - math::EPS);
         phi = CLAMP(phi, MIN_PHI, MAX_PHI);
     }
 
     /// The distance from the origin to the end point
-    Scalar_T rho = static_cast<Scalar_T>(0.0);
+    T rho = static_cast<T>(0.0);
     /// The polar angle (measured w.r.t. the positive Z-axis)
-    Scalar_T phi = static_cast<Scalar_T>(0.0);
+    T phi = static_cast<T>(0.0);
     /// The azimuthal angle (measured w.r.t. the positive X-axis)
-    Scalar_T theta = static_cast<Scalar_T>(0.0);
+    T theta = static_cast<T>(0.0);
 };
 
 }  // namespace math

--- a/include/math/vec2_t_decl.hpp
+++ b/include/math/vec2_t_decl.hpp
@@ -19,7 +19,7 @@ namespace math {
 ///
 /// \brief Class representation of a vector in 2d-space
 ///
-/// \tparam Scalar_T Type of scalar value used for this 2d-vector (float|double)
+/// \tparam T Type of scalar value used for this 2d-vector (float|double)
 ///
 /// This is a class that represents a 2d-vector with entries x, y of some
 /// scalar floating-point type. Its storage is a buffer of the given scalar
@@ -27,7 +27,7 @@ namespace math {
 /// between adding padding/size and usage of aligned load/store). So, SIMD
 /// kernels are build using unaligned load/store operations (unlike friends like
 /// vec3 and vec4 types)
-template <typename Scalar_T>
+template <typename T>
 struct Vector2 {
     /// Number of scalars used in the storage of the vector
     static constexpr uint32_t BUFFER_SIZE = 2;
@@ -37,45 +37,45 @@ struct Vector2 {
     static constexpr uint32_t VECTOR_NDIM = 1;
 
     /// Type alias of the vector
-    using Type = Vector2<Scalar_T>;
+    using Type = Vector2<T>;
     /// Type alias of the scalar used for this vector (float32|64)
-    using ElementType = Scalar_T;
+    using ElementType = T;
     /// Type alias of the internal storage used for the vector (i.e. std::array)
-    using BufferType = std::array<Scalar_T, BUFFER_SIZE>;
+    using BufferType = std::array<T, BUFFER_SIZE>;
 
     /// Constructs a zero-initialized vector
     Vector2() = default;
 
     /// Constructs a vector of the form (x, x)
-    explicit Vector2(Scalar_T x_coord) {
+    explicit Vector2(T x_coord) {
         m_Elements[0] = x_coord;
         m_Elements[1] = x_coord;
     }
 
     /// Constructs a vector of the form (x, y)
-    explicit Vector2(Scalar_T x_coord, Scalar_T y_coord) {
+    explicit Vector2(T x_coord, T y_coord) {
         m_Elements[0] = x_coord;
         m_Elements[1] = y_coord;
     }
 
     // cppcheck-suppress noExplicitConstructor
     /// Constructs a vector from an initializer list of the form {x, y}
-    Vector2(const std::initializer_list<Scalar_T>& values) {
-        assert(values.size() == Vector2<Scalar_T>::VECTOR_SIZE);
+    Vector2(const std::initializer_list<T>& values) {
+        assert(values.size() == Vector2<T>::VECTOR_SIZE);
         std::copy(values.begin(), values.end(), m_Elements.data());
     }
 
     /// Returns a mutable reference to the x-component of the vector
-    auto x() -> Scalar_T& { return m_Elements[0]; }
+    auto x() -> T& { return m_Elements[0]; }
 
     /// Returns a mutable reference to the y-component of the vector
-    auto y() -> Scalar_T& { return m_Elements[1]; }
+    auto y() -> T& { return m_Elements[1]; }
 
     /// Returns an unmutable reference to the x-component of the vector
-    auto x() const -> const Scalar_T& { return m_Elements[0]; }
+    auto x() const -> const T& { return m_Elements[0]; }
 
     /// Returns an unmutable reference to the y-component of the vector
-    auto y() const -> const Scalar_T& { return m_Elements[1]; }
+    auto y() const -> const T& { return m_Elements[1]; }
 
     /// Returns a mutable reference to the underlying storage of the vector
     auto elements() -> BufferType& { return m_Elements; }
@@ -84,21 +84,21 @@ struct Vector2 {
     auto elements() const -> const BufferType& { return m_Elements; }
 
     /// Returns a pointer to the data of the underlying storage in use
-    auto data() -> Scalar_T* { return m_Elements.data(); }
+    auto data() -> T* { return m_Elements.data(); }
 
     /// Reeturns a const-pointer to the data of the underlying storage in use
-    auto data() const -> const Scalar_T* { return m_Elements.data(); }
+    auto data() const -> const T* { return m_Elements.data(); }
 
     /// Returns a mutable reference to the requested entry of the vector
-    auto operator[](uint32_t index) -> Scalar_T& { return m_Elements[index]; }
+    auto operator[](uint32_t index) -> T& { return m_Elements[index]; }
 
     /// Returns an unmutable reference to the requested entry of the vector
-    auto operator[](uint32_t index) const -> const Scalar_T& {
+    auto operator[](uint32_t index) const -> const T& {
         return m_Elements[index];
     }
 
     /// Returns a comma-initializer to construct the vector via its coefficients
-    auto operator<<(Scalar_T coeff) -> VecCommaInitializer<Type> {
+    auto operator<<(T coeff) -> VecCommaInitializer<Type> {
         return VecCommaInitializer<Type>(*this, coeff);
     }
 

--- a/include/math/vec3_t_decl.hpp
+++ b/include/math/vec3_t_decl.hpp
@@ -16,7 +16,7 @@
 
 namespace math {
 
-template <typename Scalar_T>
+template <typename T>
 class Vector4;
 
 }  // namespace math
@@ -27,12 +27,12 @@ namespace math {
 ///
 /// \brief Class representation of a vector in 3d-space
 ///
-/// \tparam Scalar_T Type of scalar value used for this 3d-vector (float|double)
+/// \tparam T Type of scalar value used for this 3d-vector (float|double)
 ///
 /// This is a class that represents a 3d-vector with entries x, y, z of some
 /// scalar floating-point type. Its storage is a buffer of the given scalar
 /// type, and contains only the required storage for 3 elements.
-template <typename Scalar_T>
+template <typename T>
 class Vector3 {
  public:
     /// Number of scalars used in the storage of the vector
@@ -43,34 +43,34 @@ class Vector3 {
     static constexpr uint32_t VECTOR_NDIM = 1;
 
     /// Typename of the vector
-    using Type = Vector3<Scalar_T>;
+    using Type = Vector3<T>;
     /// Typename of the scalar used for the vector (float32, float64, etc.)
-    using ElementType = Scalar_T;
+    using ElementType = T;
     /// Typename of the internal storage used for the vector
-    using BufferType = std::array<Scalar_T, BUFFER_SIZE>;
+    using BufferType = std::array<T, BUFFER_SIZE>;
 
     // Some related types
-    using Vec4 = Vector4<Scalar_T>;
+    using Vec4 = Vector4<T>;
 
     /// Constructs a zero-initialized vector
     Vector3() = default;
 
     /// Constructs a vector of the form (x, x, x)
-    explicit Vector3(Scalar_T x_coord) {
+    explicit Vector3(T x_coord) {
         m_Elements[0] = x_coord;
         m_Elements[1] = x_coord;
         m_Elements[2] = x_coord;
     }
 
     /// Constructs a vector of the form (x, y, y)
-    explicit Vector3(Scalar_T x_coord, Scalar_T y_coord) {
+    explicit Vector3(T x_coord, T y_coord) {
         m_Elements[0] = x_coord;
         m_Elements[1] = y_coord;
         m_Elements[2] = y_coord;
     }
 
     /// Constructs a vector of the form (x, y, z)
-    explicit Vector3(Scalar_T x_coord, Scalar_T y_coord, Scalar_T z_coord) {
+    explicit Vector3(T x_coord, T y_coord, T z_coord) {
         m_Elements[0] = x_coord;
         m_Elements[1] = y_coord;
         m_Elements[2] = z_coord;
@@ -85,30 +85,30 @@ class Vector3 {
 
     // cppcheck-suppress noExplicitConstructor
     /// COnstructs a vector from an initializer list of the form {x, y, z}
-    Vector3(const std::initializer_list<Scalar_T>& values) {
+    Vector3(const std::initializer_list<T>& values) {
         // Complain in case we don't receive exactly 3 values
-        assert(values.size() == Vector3<Scalar_T>::VECTOR_SIZE);
+        assert(values.size() == Vector3<T>::VECTOR_SIZE);
         // Just copy the whole data from the initializer list
         std::copy(values.begin(), values.end(), m_Elements.data());
     }
 
     /// Returns a mutable reference to the x-component of the vector
-    auto x() -> Scalar_T& { return m_Elements[0]; }
+    auto x() -> T& { return m_Elements[0]; }
 
     /// Returns a mutable reference to the y-component of the vector
-    auto y() -> Scalar_T& { return m_Elements[1]; }
+    auto y() -> T& { return m_Elements[1]; }
 
     /// Returns a mutable reference to the z-component of the vector
-    auto z() -> Scalar_T& { return m_Elements[2]; }
+    auto z() -> T& { return m_Elements[2]; }
 
     /// Returns an unmutable reference to the x-component of the vector
-    auto x() const -> const Scalar_T& { return m_Elements[0]; }
+    auto x() const -> const T& { return m_Elements[0]; }
 
     /// Returns an unmutable reference to the y-component of the vector
-    auto y() const -> const Scalar_T& { return m_Elements[1]; }
+    auto y() const -> const T& { return m_Elements[1]; }
 
     /// Returns an unmutable reference to the z-component of the vector
-    auto z() const -> const Scalar_T& { return m_Elements[2]; }
+    auto z() const -> const T& { return m_Elements[2]; }
 
     /// Returns a mutable reference to the underlying storage of the vector
     auto elements() -> BufferType& { return m_Elements; }
@@ -117,21 +117,21 @@ class Vector3 {
     auto elements() const -> const BufferType& { return m_Elements; }
 
     /// Returns a pointer to the data of the underlying storage in use
-    auto data() -> Scalar_T* { return m_Elements.data(); }
+    auto data() -> T* { return m_Elements.data(); }
 
     /// Reeturns a const-pointer to the data of the underlying storage in use
-    auto data() const -> const Scalar_T* { return m_Elements.data(); }
+    auto data() const -> const T* { return m_Elements.data(); }
 
     /// Returns a mutable reference to the requested entry of the vector
-    auto operator[](uint32_t index) -> Scalar_T& { return m_Elements[index]; }
+    auto operator[](uint32_t index) -> T& { return m_Elements[index]; }
 
     /// Returns an unmutable reference to the requested entry of the vector
-    auto operator[](uint32_t index) const -> const Scalar_T& {
+    auto operator[](uint32_t index) const -> const T& {
         return m_Elements[index];
     }
 
     /// Returns a comma-initializer to construct the vector via its coefficients
-    auto operator<<(Scalar_T coeff) -> VecCommaInitializer<Type> {
+    auto operator<<(T coeff) -> VecCommaInitializer<Type> {
         return VecCommaInitializer<Type>(*this, coeff);
     }
 

--- a/include/math/vec4_t_decl.hpp
+++ b/include/math/vec4_t_decl.hpp
@@ -16,7 +16,7 @@
 
 namespace math {
 
-template <typename Scalar_T>
+template <typename T>
 class Vector3;
 
 }  // namespace math
@@ -27,13 +27,13 @@ namespace math {
 ///
 /// \brief Class representation of a vector in 4d-space
 ///
-/// \tparam Scalar_T Type of scalar value used for this 4d-vector (float|double)
+/// \tparam T Type of scalar value used for this 4d-vector (float|double)
 ///
 /// This is a class that represents a 4d-vector with entries x, y, z, w of some
 /// scalar floating-point type. Its storage is a buffer of the given scalar
 /// type, and it's aligned accordingly in order to use the aligned versions of
 /// some SIMD instructions (when using either SSE or AVX intrinsics).
-template <typename Scalar_T>
+template <typename T>
 class Vector4 {
  public:
     /// Number of scalars used in the storage of the vector
@@ -44,20 +44,20 @@ class Vector4 {
     static constexpr uint32_t VECTOR_NDIM = 1;
 
     /// Typename of the vector
-    using Type = Vector4<Scalar_T>;
+    using Type = Vector4<T>;
     /// Typename of the scalar used for the vector (float32, float64, etc.)
-    using ElementType = Scalar_T;
+    using ElementType = T;
     /// Typename of the internal storage used for the vector
-    using BufferType = std::array<Scalar_T, BUFFER_SIZE>;
+    using BufferType = std::array<T, BUFFER_SIZE>;
 
     // Some related types
-    using Vec3 = Vector3<Scalar_T>;
+    using Vec3 = Vector3<T>;
 
     /// Constructs a zero-initialized vector
     Vector4() = default;
 
     /// Constructs a vector of the form (x, x, x, x)
-    explicit Vector4(Scalar_T x_coord) {
+    explicit Vector4(T x_coord) {
         m_Elements[0] = x_coord;
         m_Elements[1] = x_coord;
         m_Elements[2] = x_coord;
@@ -65,7 +65,7 @@ class Vector4 {
     }
 
     /// Constructs a vector of the form (x, y, y, y)
-    explicit Vector4(Scalar_T x_coord, Scalar_T y_coord) {
+    explicit Vector4(T x_coord, T y_coord) {
         m_Elements[0] = x_coord;
         m_Elements[1] = y_coord;
         m_Elements[2] = y_coord;
@@ -73,7 +73,7 @@ class Vector4 {
     }
 
     /// Constructs a vector of the form (x, y, z, z)
-    explicit Vector4(Scalar_T x_coord, Scalar_T y_coord, Scalar_T z_coord) {
+    explicit Vector4(T x_coord, T y_coord, T z_coord) {
         m_Elements[0] = x_coord;
         m_Elements[1] = y_coord;
         m_Elements[2] = z_coord;
@@ -81,8 +81,7 @@ class Vector4 {
     }
 
     /// Constructs a vector of the form (x, y, z, w)
-    explicit Vector4(Scalar_T x_coord, Scalar_T y_coord, Scalar_T z_coord,
-                     Scalar_T w_coord) {
+    explicit Vector4(T x_coord, T y_coord, T z_coord, T w_coord) {
         m_Elements[0] = x_coord;
         m_Elements[1] = y_coord;
         m_Elements[2] = z_coord;
@@ -99,9 +98,9 @@ class Vector4 {
 
     // cppcheck-suppress noExplicitConstructor
     /// Constructs a vector from an initializer list of the form {x, y, z, w}
-    Vector4(const std::initializer_list<Scalar_T>& values) {
+    Vector4(const std::initializer_list<T>& values) {
         // Complain in case we don't receive exactly 4 values
-        assert(values.size() == Vector4<Scalar_T>::VECTOR_SIZE);
+        assert(values.size() == Vector4<T>::VECTOR_SIZE);
         // Just copy the whole data from the initializer list
         std::copy(values.begin(), values.end(), m_Elements.data());
     }
@@ -109,28 +108,28 @@ class Vector4 {
     // @todo(wilbert): RAII break (rule of 5)
 
     /// Returns a mutable reference to the x-component of the vector
-    auto x() -> Scalar_T& { return m_Elements[0]; }
+    auto x() -> T& { return m_Elements[0]; }
 
     /// Returns a mutable reference to the y-component of the vector
-    auto y() -> Scalar_T& { return m_Elements[1]; }
+    auto y() -> T& { return m_Elements[1]; }
 
     /// Returns a mutable reference to the z-component of the vector
-    auto z() -> Scalar_T& { return m_Elements[2]; }
+    auto z() -> T& { return m_Elements[2]; }
 
     /// Returns a mutable reference to the w-component of the vector
-    auto w() -> Scalar_T& { return m_Elements[3]; }
+    auto w() -> T& { return m_Elements[3]; }
 
     /// Returns an unmutable reference to the x-component of the vector
-    auto x() const -> const Scalar_T& { return m_Elements[0]; }
+    auto x() const -> const T& { return m_Elements[0]; }
 
     /// Returns an unmutable reference to the y-component of the vector
-    auto y() const -> const Scalar_T& { return m_Elements[1]; }
+    auto y() const -> const T& { return m_Elements[1]; }
 
     /// Returns an unmutable reference to the z-component of the vector
-    auto z() const -> const Scalar_T& { return m_Elements[2]; }
+    auto z() const -> const T& { return m_Elements[2]; }
 
     /// Returns an unmutable reference to the w-component of the vector
-    auto w() const -> const Scalar_T& { return m_Elements[3]; }
+    auto w() const -> const T& { return m_Elements[3]; }
 
     /// Returns a mutable reference to the underlying storage of the vector
     auto elements() -> BufferType& { return m_Elements; }
@@ -139,21 +138,21 @@ class Vector4 {
     auto elements() const -> const BufferType& { return m_Elements; }
 
     /// Returns a pointer to the data of the underlying storage in use
-    auto data() -> Scalar_T* { return m_Elements.data(); }
+    auto data() -> T* { return m_Elements.data(); }
 
     /// Reeturns a const-pointer to the data of the underlying storage in use
-    auto data() const -> const Scalar_T* { return m_Elements.data(); }
+    auto data() const -> const T* { return m_Elements.data(); }
 
     /// Returns a mutable reference to the requested entry of the vector
-    auto operator[](uint32_t index) -> Scalar_T& { return m_Elements[index]; }
+    auto operator[](uint32_t index) -> T& { return m_Elements[index]; }
 
     /// Returns an unmutable reference to the requested entry of the vector
-    auto operator[](uint32_t index) const -> const Scalar_T& {
+    auto operator[](uint32_t index) const -> const T& {
         return m_Elements[index];
     }
 
     /// Returns a comma-initializer to construct the vector via its coefficients
-    auto operator<<(Scalar_T coeff) -> VecCommaInitializer<Type> {
+    auto operator<<(T coeff) -> VecCommaInitializer<Type> {
         return VecCommaInitializer<Type>(*this, coeff);
     }
 


### PR DESCRIPTION
# Description

- This PR updates all math types (e.g. `pose3d_t`) to use as template argument `T` instead of `Scalar_T`. This helps by fixing some multiple declaration issues when generating documentation using `Doxygen`.
- It also makes some minor tweaks to make it work with both `Doxygen` and `Sphinx`.